### PR TITLE
 Bootstrap actions & probes for compute operations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+ignore = E203, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: flake8
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort
+        args: [--profile, black]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+PROJECT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+VIRTUALENV_DIR := $(PROJECT_DIR)/venv
+VIRTUAL_ENV_DISABLE_PROMPT = true
+
+.SHELLFLAGS := -eu -o pipefail -c
+
+PATH := $(VIRTUALENV_DIR)/bin:$(EXTRA_PATH):/usr/local/bin:/bin:$(PATH)
+export PATH
+
+help:
+	@grep -E '^[a-zA-Z1-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| sort \
+		| awk 'BEGIN { FS = ":.*?## " }; { printf "\033[36m%-30s\033[0m %s\n", $$1, $$2 }'
+
+$(VIRTUALENV_DIR):
+	virtualenv -p $(shell command -v python3) $(VIRTUALENV_DIR)
+
+$(VIRTUALENV_DIR)/bin: requirements.txt
+	pip install -r requirements.txt
+	@touch '$(@)'
+
+$(VIRTUALENV_DIR)/bin/black: requirements-dev.txt
+	pip install -r requirements-dev.txt
+	python setup.py develop
+	@touch '$(@)'
+
+pre-commit-install: ## Install pre-commit hooks
+		pre-commit install
+
+install: $(VIRTUALENV_DIR) $(VIRTUALENV_DIR)/bin ## Install project
+
+install-dev: install $(VIRTUALENV_DIR)/bin/black ## Install project for development
+	$(info Run make pre-commit-install to install git hooks)
+
+lint: ## Run flake8, isort and black linters
+	flake8 chaosopenstack/ tests/
+	isort --check-only --profile black chaosopenstack/ tests/
+	black --check --diff chaosopenstack/ tests/
+
+format: ## Run isort and black formaters
+	isort --profile black chaosopenstack/ tests/
+	black chaosopenstack/ tests/
+
+tests: ## Run python test suite
+	pytest
+	coverage html
+
+.PHONY: format lint tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- # Chaos Toolkit Extension for Open Stack.
+# Chaos Toolkit Extension for OpenStack.
 
 [![Python versions](https://img.shields.io/pypi/pyversions/chaostoolkit-openstack.svg)](https://www.python.org/)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Python versions](https://img.shields.io/pypi/pyversions/chaostoolkit-openstack.svg)](https://www.python.org/)
 
-
 This project is a collection of [actions][] and [probes][], gathered as an
 extension to the [Chaos Toolkit][chaostoolkit].
 
@@ -27,8 +26,51 @@ To use the probes and actions from this package, add the following to your
 experiment file:
 
 ```json
-
-
+{
+  "title": "bastion-stop-start",
+  "description": "Stop/Start a bastion instance randomly",
+  "tags": [],
+  "configuration": {
+    "openstack_cloud": "prd",
+    "openstack_regions": ["REGION1", "REGION2"]
+  },
+  "method": [
+    {
+      "type": "action",
+      "name": "terminate-bastion-instance",
+      "provider": {
+        "type": "python",
+        "module": "chaosopenstack.compute.actions",
+        "func": "stop_instances",
+        "arguments": {
+          "rand": true,
+          "filters": {
+            "name": "prd-bastion-*"
+          }
+        }
+      },
+      "pauses": {
+        "after": 120
+      }
+    }
+  ],
+  "rollbacks": [
+    {
+      "type": "action",
+      "name": "start-bastion-instance",
+      "provider": {
+        "type": "python",
+        "module": "chaosopenstack.compute.actions",
+        "func": "start_instances",
+        "arguments": {
+          "filters": {
+            "name": "prd-bastion-*"
+          }
+        }
+      }
+    }
+  ]
+}
 ```
 
 That's it!
@@ -37,6 +79,23 @@ Please explore the code to see existing probes and actions.
 
 ## Configuration
 
+This extension uses the [openstacksdk][] library under the hood. This library expects
+that you have properly [configured][config] your environment to connect and
+authenticate with the Openstack APIs.
+
+[openstacksdk]: https://docs.openstack.org/openstacksdk/latest/index.html
+[config]: https://docs.openstack.org/openstacksdk/latest/user/guides/connect_from_config.html
+
+### Use default profile from `~/.config/openstack/clouds.yml` or `/etc/openstack`
+
+This is the most basic case, assuming your `default` profile is properly
+configured in `~/.config/openstack/clouds.yml` (or `/etc/openstack`),
+then you do not need to pass any specific credentials to the experiment.
+
+### Use profile from a custom path
+
+You can export the `OS_CLIENT_CONFIG_FILE` to target a specific Config File, in this case
+also you do not need to pass any specific credentials to the experiment.
 
 ## Contribute
 

--- a/chaosopenstack/__init__.py
+++ b/chaosopenstack/__init__.py
@@ -1,5 +1,63 @@
 # -*- coding: utf-8 -*-
 
-"""Top-level package for chaostoolkit-openstack."""
+from typing import List
 
-__version__ = '0.1.0'
+from chaoslib.discovery.discover import (
+    discover_actions,
+    discover_probes,
+    initialize_discovery_result,
+)
+from chaoslib.exceptions import InterruptExecution
+from chaoslib.types import Configuration, DiscoveredActivities, Discovery, Secrets
+from logzero import logger
+
+from chaosopenstack.client import OpenstackClientWrapper
+
+__version__ = "0.1.0"
+
+__all__ = ["discover", "__version__"]
+
+
+def openstack_client(configuration: Configuration = None, secrets: Secrets = None):
+    """
+    Create and return an openstack connection.
+
+    Only Config Files are supported, because the same config can be used across tools and languages.
+    cf. https://docs.openstack.org/openstacksdk/latest/user/guides/connect_from_config.html
+    """  # noqa 508
+
+    cloud = configuration.get("openstack_cloud")
+    regions = configuration.get("openstack_regions")
+
+    if not regions:
+        raise InterruptExecution("Openstack requires at least one region to be set!")
+
+    return OpenstackClientWrapper(cloud, regions)
+
+
+def discover(discover_system: bool = True) -> Discovery:
+    """
+    Discover Openstack capabilities offered by this extension.
+    """
+    logger.info("Discovering capabilities from chaostoolkit-openstack")
+
+    discovery = initialize_discovery_result(
+        "chaostoolkit-openstack", __version__, "openstack"
+    )
+    discovery["activities"].extend(load_exported_activities())
+
+    return discovery
+
+
+###############################################################################
+# Private functions
+###############################################################################
+def load_exported_activities() -> List[DiscoveredActivities]:
+    """
+    Extract metadata from actions and probes exposed by this extension.
+    """
+    activities = []
+    activities.extend(discover_actions("chaosopenstack.compute.actions"))
+    activities.extend(discover_probes("chaosopenstack.compute.probes"))
+
+    return activities

--- a/chaosopenstack/client.py
+++ b/chaosopenstack/client.py
@@ -1,0 +1,49 @@
+from collections import OrderedDict
+
+import openstack
+
+
+class OpenstackComputeWrapper:
+    """
+    OpenstackComputeWrapper provides some of the compute API methods over
+    multiple Openstack regions.
+
+    https://docs.openstack.org/openstacksdk/latest/user/guides/compute.html
+    """
+
+    def __init__(self, conns):
+        self._conns = conns
+
+    def servers(self, **filters):
+        instances = []
+        for region in self._conns.keys():
+            instances.extend(list(self._conns[region].compute.servers(**filters)))
+
+        return [instance.to_dict() for instance in instances]
+
+    def stop_server(self, instance):
+        self._conns[instance["location"]["region_name"]].compute.stop_server(instance)
+
+    def start_server(self, instance):
+        self._conns[instance["location"]["region_name"]].compute.start_server(instance)
+
+
+class OpenstackClientWrapper:
+    """
+    OpenstackClientWrapper provides a single interface to manage openstack APIs
+    over multiple regions.
+
+    https://docs.openstack.org/openstacksdk/latest/user/guides/connect.html
+    """
+
+    def __init__(self, cloud, regions):
+
+        # TODO activate this when --verbose flag is set
+        # openstack.enable_logging(debug=True)
+
+        self._conns = OrderedDict()
+
+        for region in regions:
+            self._conns[region] = openstack.connect(cloud=cloud, region_name=region)
+
+        self.compute = OpenstackComputeWrapper(self._conns)

--- a/chaosopenstack/compute/actions.py
+++ b/chaosopenstack/compute/actions.py
@@ -1,0 +1,77 @@
+import random
+from typing import Any, Dict, List
+
+from chaoslib.types import Configuration, Secrets
+from logzero import logger
+
+from chaosopenstack import openstack_client
+from chaosopenstack.types import OpenstackResponse
+
+__all__ = [
+    "stop_instances",
+    "start_instances",
+]
+
+
+def stop_instances(
+    filters: List[Dict[str, Any]],
+    rand: bool = False,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[OpenstackResponse]:
+    """
+    Stop OpenStack instance(s)
+
+    Instances are targeted by providing filters.
+    https://docs.openstack.org/api-ref/compute/?expanded=list-servers-detail#list-servers
+    """
+    response = []
+
+    client = openstack_client(configuration, secrets)
+    instances = client.compute.servers(**filters)
+
+    if rand:
+        instances = [random.choice(instances)]
+
+    for instance in instances:
+        if instance["status"] != "ACTIVE":
+            logger.info(
+                "Skip instance {} [{}] ({})".format(
+                    instance["name"], instance["id"], instance["status"]
+                )
+            )
+            continue
+
+        logger.info("Stop instance {} [{}]".format(instance["name"], instance["id"]))
+        client.compute.stop_server(instance)
+        response.append(instance)
+
+
+def start_instances(
+    filters: List[Dict[str, Any]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[OpenstackResponse]:
+    """
+    Start OpenStack instance(s)
+
+    Instances are targeted by providing filters.
+    https://docs.openstack.org/api-ref/compute/?expanded=list-servers-detail#list-servers
+    """
+    response = []
+
+    client = openstack_client(configuration, secrets)
+    instances = client.compute.servers(**filters)
+
+    for instance in instances:
+        if instance["status"] != "SHUTOFF":
+            logger.info(
+                "Skip instance {} [{}] ({})".format(
+                    instance["name"], instance["id"], instance["status"]
+                )
+            )
+            continue
+
+        logger.info("Start instance {} [{}]".format(instance["name"], instance["id"]))
+        client.compute.start_server(instance)
+        response.append(instance)

--- a/chaosopenstack/compute/probes.py
+++ b/chaosopenstack/compute/probes.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict, List
+
+from chaoslib.types import Configuration, Secrets
+
+from chaosopenstack import openstack_client
+from chaosopenstack.types import OpenstackResponse
+
+__all__ = ["describe_instances", "count_instances", "instances_state"]
+
+
+def describe_instances(
+    filters: List[Dict[str, Any]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> List[OpenstackResponse]:
+    """
+    Describe instances following the specified filters.
+    """
+    client = openstack_client(configuration, secrets)
+    instances = client.compute.servers(**filters)
+
+    return [instance.to_dict() for instance in instances]
+
+
+def count_instances(
+    filters: List[Dict[str, Any]],
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> int:
+    """
+    Return count of instances matching the specified filters.
+    """
+    client = openstack_client(configuration, secrets)
+    instances = client.compute.servers(details=False, **filters)
+
+    return sum(1 for x in instances)
+
+
+def instances_state(
+    state: str,
+    filters: List[Dict[str, Any]] = None,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> bool:
+    """Determines if compute instances match desired state"""
+    client = openstack_client(configuration, secrets)
+    instances = client.compute.servers(details=False, **filters)
+    for instance in instances:
+        if instance.vm_state != state:
+            return False
+
+    return True

--- a/chaosopenstack/types.py
+++ b/chaosopenstack/types.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+from typing import Any, Dict
+
+__all__ = ["OpenstackResponse"]
+
+# really dependent on the type of resource called
+OpenstackResponse = Dict[str, Any]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage
+pre-commit
 pycodestyle
 pytest>=2.8
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 chaostoolkit-lib>=1.1.2
+openstacksdk>=0.59
 logzero

--- a/setup.py
+++ b/setup.py
@@ -1,52 +1,50 @@
 #!/usr/bin/env python
 """chaostoolkit-openstack extension builder and installer"""
 
-import sys
 import io
+import sys
 
 import setuptools
 
 name = 'chaostoolkit-openstack'
 desc = 'Chaos Toolkit Extension for Open Stack.'
 
-with io.open('README.md', encoding='utf-8') as strm:
+with io.open("README.md", encoding="utf-8") as strm:
     long_desc = strm.read()
 
 classifiers = [
-    'Development Status :: 2 - Pre-Alpha',
-    'Intended Audience :: Developers',
-    'License :: Freely Distributable',
-    'Operating System :: OS Independent',
-    'License :: OSI Approved :: Apache Software License',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: Implementation',
-    'Programming Language :: Python :: Implementation :: CPython'
+    "Development Status :: 2 - Pre-Alpha",
+    "Intended Audience :: Developers",
+    "License :: Freely Distributable",
+    "Operating System :: OS Independent",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: Implementation",
+    "Programming Language :: Python :: Implementation :: CPython",
 ]
 author = "chaostoolkit Team"
-author_email = 'contact@chaostoolkit.org'
-url = 'http://chaostoolkit.org'
-license = 'Apache License Version 2.0'
-packages = [
-    'chaosopenstack'
-]
+author_email = "contact@chaostoolkit.org"
+url = "http://chaostoolkit.org"
+license = "Apache License Version 2.0"
+packages = ["chaosopenstack"]
 
-needs_pytest = set(['pytest', 'test']).intersection(sys.argv)
-pytest_runner = ['pytest_runner'] if needs_pytest else []
+needs_pytest = set(["pytest", "test"]).intersection(sys.argv)
+pytest_runner = ["pytest_runner"] if needs_pytest else []
 
 test_require = []
-with io.open('requirements-dev.txt') as f:
-    test_require = [l.strip() for l in f if not l.startswith('#')]
+with io.open("requirements-dev.txt") as f:
+    test_require = [l.strip() for l in f if not l.startswith("#")]
 
 install_require = []
-with io.open('requirements.txt') as f:
-    install_require = [l.strip() for l in f if not l.startswith('#')]
+with io.open("requirements.txt") as f:
+    install_require = [l.strip() for l in f if not l.startswith("#")]
 
 setup_params = dict(
     name=name,
-    version='0.1.0',
+    version="0.1.0",
     description=desc,
     long_description=long_desc,
     classifiers=classifiers,
@@ -59,7 +57,7 @@ setup_params = dict(
     install_requires=install_require,
     tests_require=test_require,
     setup_requires=pytest_runner,
-    python_requires='>=3.5.*'
+    python_requires=">=3.5.*",
 )
 
 
@@ -68,5 +66,5 @@ def main():
     setuptools.setup(**setup_params)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ import sys
 
 import setuptools
 
-name = 'chaostoolkit-openstack'
-desc = 'Chaos Toolkit Extension for Open Stack.'
+name = "chaostoolkit-openstack"
+desc = "Chaos Toolkit Extension for OpenStack."
 
 with io.open("README.md", encoding="utf-8") as strm:
     long_desc = strm.read()

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,25 @@
 """chaostoolkit-openstack extension builder and installer"""
 
 import io
+import os
 import sys
 
 import setuptools
+
+
+def get_version_from_package() -> str:
+    """
+    Read the package version from the source without importing it.
+    """
+    path = os.path.join(os.path.dirname(__file__), "chaosopenstack/__init__.py")
+    path = os.path.normpath(os.path.abspath(path))
+    with open(path) as f:
+        for line in f:
+            if line.startswith("__version__"):
+                token, version = line.split(" = ", 1)
+                version = version.replace('"', "").strip()
+                return version
+
 
 name = "chaostoolkit-openstack"
 desc = "Chaos Toolkit Extension for OpenStack."
@@ -44,7 +60,7 @@ with io.open("requirements.txt") as f:
 
 setup_params = dict(
     name=name,
-    version="0.1.0",
+    version=get_version_from_package(),
     description=desc,
     long_description=long_desc,
     classifiers=classifiers,

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ author = "chaostoolkit Team"
 author_email = "contact@chaostoolkit.org"
 url = "http://chaostoolkit.org"
 license = "Apache License Version 2.0"
-packages = ["chaosopenstack"]
+packages = setuptools.find_packages(include=["chaosopenstack", "chaosopenstack.*"])
 
 needs_pytest = set(["pytest", "test"]).intersection(sys.argv)
 pytest_runner = ["pytest_runner"] if needs_pytest else []

--- a/tests/compute/test_client.py
+++ b/tests/compute/test_client.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock, call, patch
+
+from chaosopenstack.client import OpenstackClientWrapper, OpenstackComputeWrapper
+
+
+@patch("chaosopenstack.client.openstack", autospec=True)
+def test_OpenstackClientWrapper_connect(openstack: object):
+    OpenstackClientWrapper("myproject", ["REGION1", "REGION2"])
+
+    openstack.connect.assert_has_calls(
+        [
+            call(cloud="myproject", region_name="REGION1"),
+            call(cloud="myproject", region_name="REGION2"),
+        ]
+    )
+
+
+@patch("chaosopenstack.client.openstack", autospec=True)
+def test_OpenstackComputeWrapper_servers(openstack: object):
+    instances = [
+        {
+            "status": "SHUTOFF",
+            "vm_state": "stopped",
+            "id": "0b7a8371-24cf-4855-b3d2-e30f2cb13ddc",
+            "name": "staging-bastion-region1-01",
+            "location": {"cloud": "staging", "region_name": "REGION1"},
+        },
+        {
+            "status": "ACTIVE",
+            "vm_state": "active",
+            "id": "93746749-331d-4ec4-b536-4ce73889e78f",
+            "name": "staging-bastion-region2-02",
+            "location": {
+                "cloud": "staging",
+                "region_name": "REGION2",
+            },
+        },
+    ]
+
+    instance1 = MagicMock()
+    instance1.to_dict.return_value = instances[0]
+
+    instance2 = MagicMock()
+    instance2.to_dict.return_value = instances[1]
+
+    client_region1 = MagicMock()
+    client_region1.compute.servers.return_value = [instance1]
+    client_region2 = MagicMock()
+    client_region2.compute.servers.return_value = [instance2]
+    conns = {"REGION1": client_region1, "REGION2": client_region2}
+
+    compute = OpenstackComputeWrapper(conns)
+    response = compute.servers()
+
+    assert instances == response
+
+
+@patch("chaosopenstack.client.openstack", autospec=True)
+def test_OpenstackComputeWrapper_stop_server(openstack: object):
+    instance = {
+        "status": "ACTIVE",
+        "vm_state": "active",
+        "id": "0b7a8371-24cf-4855-b3d2-e30f2cb13ddc",
+        "name": "staging-bastion-region1-01",
+        "location": {"cloud": "staging", "region_name": "REGION1"},
+    }
+
+    client_region1 = MagicMock()
+    client_region2 = MagicMock()
+    conns = {"REGION1": client_region1, "REGION2": client_region2}
+
+    compute = OpenstackComputeWrapper(conns)
+    compute.stop_server(instance)
+
+    client_region1.compute.stop_server.assert_called_once_with(instance)
+    assert client_region2.compute.stop_server.call_count == 0
+
+
+@patch("chaosopenstack.client.openstack", autospec=True)
+def test_OpenstackComputeWrapper_start_server(openstack: object):
+    instance = {
+        "status": "SHUTOFF",
+        "vm_state": "stopped",
+        "id": "93746749-331d-4ec4-b536-4ce73889e78f",
+        "name": "staging-bastion-region2-02",
+        "location": {"cloud": "staging", "region_name": "REGION2"},
+    }
+
+    client_region1 = MagicMock()
+    client_region1.compute.servers.return_value = instance
+
+    client_region1 = MagicMock()
+    client_region2 = MagicMock()
+    conns = {"REGION1": client_region1, "REGION2": client_region2}
+
+    compute = OpenstackComputeWrapper(conns)
+    compute.start_server(instance)
+
+    assert client_region1.compute.start_server.call_count == 0
+    client_region2.compute.start_server.assert_called_once_with(instance)

--- a/tests/compute/test_compute_actions.py
+++ b/tests/compute/test_compute_actions.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock, patch
+
+from chaosopenstack.compute.actions import start_instances, stop_instances
+
+
+@patch("chaosopenstack.compute.actions.openstack_client", autospec=True)
+def test_stop_instances(openstack_client):
+    client = MagicMock()
+
+    instances = [
+        {
+            "status": "SHUTOFF",
+            "vm_state": "stopped",
+            "id": "0b7a8371-24cf-4855-b3d2-e30f2cb13ddc",
+            "name": "staging-bastion-region1-01",
+            "location": {"cloud": "staging", "region_name": "REGION1"},
+        },
+        {
+            "status": "ACTIVE",
+            "vm_state": "active",
+            "id": "93746749-331d-4ec4-b536-4ce73889e78f",
+            "name": "staging-bastion-region2-02",
+            "location": {
+                "cloud": "staging",
+                "region_name": "REGION2",
+            },
+        },
+    ]
+
+    client.compute.servers.return_value = instances
+    openstack_client.return_value = client
+
+    stop_instances({"name": "staging-bastion-*"})
+
+    client.compute.stop_server.assert_called_once_with(instances[1])
+
+
+@patch("chaosopenstack.compute.actions.openstack_client", autospec=True)
+def test_stop_instances_randomly(openstack_client):
+    client = MagicMock()
+
+    instances = [
+        {
+            "status": "ACTIVE",
+            "vm_state": "active",
+            "id": "0b7a8371-24cf-4855-b3d2-e30f2cb13ddc",
+            "name": "staging-bastion-region1-01",
+            "location": {"cloud": "staging", "region_name": "REGION1"},
+        },
+        {
+            "status": "ACTIVE",
+            "vm_state": "active",
+            "id": "93746749-331d-4ec4-b536-4ce73889e78f",
+            "name": "staging-bastion-region2-02",
+            "location": {
+                "cloud": "staging",
+                "region_name": "REGION2",
+            },
+        },
+    ]
+
+    client.compute.servers.return_value = instances
+    openstack_client.return_value = client
+
+    with patch("chaosopenstack.compute.actions.random.choice") as choice:
+        choice.return_value = instances[1]
+        stop_instances(filters={"name": "staging-bastion-*"}, rand=True)
+        choice.assert_called_once_with(instances)
+
+    client.compute.stop_server.assert_called_once_with(instances[1])
+
+
+@patch("chaosopenstack.compute.actions.openstack_client", autospec=True)
+def test_start_instances(openstack_client):
+    client = MagicMock()
+
+    instances = [
+        {
+            "status": "SHUTOFF",
+            "vm_state": "stopped",
+            "id": "0b7a8371-24cf-4855-b3d2-e30f2cb13ddc",
+            "name": "staging-bastion-region1-01",
+            "location": {"cloud": "staging", "region_name": "REGION1"},
+        },
+        {
+            "status": "ACTIVE",
+            "vm_state": "active",
+            "id": "93746749-331d-4ec4-b536-4ce73889e78f",
+            "name": "staging-bastion-region2-02",
+            "location": {
+                "cloud": "staging",
+                "region_name": "REGION2",
+            },
+        },
+    ]
+
+    client.compute.servers.return_value = instances
+    openstack_client.return_value = client
+
+    start_instances({"name": "staging-bastion-*"})
+
+    client.compute.start_server.assert_called_once_with(instances[0])

--- a/tests/compute/test_compute_probes.py
+++ b/tests/compute/test_compute_probes.py
@@ -1,0 +1,104 @@
+from unittest.mock import MagicMock, patch
+
+from chaosopenstack.compute.probes import (
+    count_instances,
+    describe_instances,
+    instances_state,
+)
+
+
+@patch("chaosopenstack.compute.probes.openstack_client", autospec=True)
+def test_describe_instances(openstack_client):
+    client, instance1, instance2 = MagicMock(), MagicMock(), MagicMock()
+    instances = [instance1, instance2]
+
+    client.compute.servers.return_value = instances
+    openstack_client.return_value = client
+
+    describe_instances({"name": "*"})
+
+    instance1.to_dict.assert_called_once()
+    instance2.to_dict.assert_called_once()
+
+
+@patch("chaosopenstack.compute.probes.openstack_client", autospec=True)
+def test_count_instances(openstack_client):
+    client, instance1, instance2 = MagicMock(), MagicMock(), MagicMock()
+    instances = [instance1, instance2]
+
+    client.compute.servers.return_value = instances
+    openstack_client.return_value = client
+
+    count = count_instances({"name": "*"})
+
+    assert count == 2
+
+
+@patch("chaosopenstack.compute.probes.openstack_client", autospec=True)
+def test_instances_state_true(openstack_client):
+    client = MagicMock()
+
+    instances = [
+        MagicMock(
+            status="ACTIVE",
+            vm_state="active",
+            id="0b7a8371-24cf-4855-b3d2-e30f2cb13ddc",
+            name="staging-bastion-region1-01",
+            location=MagicMock(
+                cloud="staging",
+                region_name="REGION1",
+            ),
+        ),
+        MagicMock(
+            status="ACTIVE",
+            vm_state="active",
+            id="93746749-331d-4ec4-b536-4ce73889e78f",
+            name="staging-bastion-region2-02",
+            location=MagicMock(
+                cloud="staging",
+                region_name="REGION2",
+            ),
+        ),
+    ]
+
+    client.compute.servers.return_value = instances
+    openstack_client.return_value = client
+
+    response = instances_state("active", {"name": "staging-bastion-*"})
+
+    assert response is True
+
+
+@patch("chaosopenstack.compute.probes.openstack_client", autospec=True)
+def test_instances_state_false(openstack_client):
+    client = MagicMock()
+
+    instances = [
+        MagicMock(
+            status="ACTIVE",
+            vm_state="active",
+            id="0b7a8371-24cf-4855-b3d2-e30f2cb13ddc",
+            name="staging-bastion-region1-01",
+            location=MagicMock(
+                cloud="staging",
+                region_name="REGION1",
+            ),
+        ),
+        MagicMock(
+            status="SHUTOFF",
+            vm_state="stopped",
+            id="93746749-331d-4ec4-b536-4ce73889e78f",
+            name="staging-bastion-region2-02",
+            location=MagicMock(
+                cloud="staging",
+                region_name="REGION2",
+            ),
+        ),
+    ]
+
+    client.compute.servers.return_value = instances
+    openstack_client.return_value = client
+
+    response = instances_state("ACTIVE", {"name": "staging-bastion-*"})
+
+    assert response is False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+import pytest
+from chaoslib.exceptions import InterruptExecution
+
+from chaosopenstack import openstack_client
+
+SECRETS = {}
+
+CONFIGURATION = {
+    "openstack_cloud": "myproject",
+    "openstack_regions": ["REGION1", "REGION2"],
+}
+
+
+@patch("chaosopenstack.OpenstackClientWrapper", autospec=True)
+def test_create_client(OpenstackClientWrapper: object):
+    openstack_client(configuration=CONFIGURATION, secrets=SECRETS)
+    OpenstackClientWrapper.assert_called_with("myproject", ["REGION1", "REGION2"])
+
+
+@patch("chaosopenstack.OpenstackClientWrapper", autospec=True)
+def test_create_client_without_regions(OpenstackClientWrapper: object):
+    with pytest.raises(InterruptExecution):
+        openstack_client(
+            configuration={"openstack_cloud": "myproject"}, secrets=SECRETS
+        )


### PR DESCRIPTION
## Description

This Pull Request brings the following features for compute operations and supports OpenStack cloud deployed over multiple regions.

### Actions

- `start_instances`
- `stop_instances` (with a random option)
 
The [following filters](https://docs.openstack.org/api-ref/compute/?expanded=list-servers-detail#list-servers) are available to target instances.

### Probes

- `describe_instances`
- `count_instances`
- `instances_state`

### Tooling

A `Makefile` and `pre-commit` were also added to help development

Signed-off-by: Maxime Loliée <maxime.loliee@mediapart.fr>